### PR TITLE
add: code and tests for suspending and unsuspending

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -222,3 +222,51 @@ def delete_customers(customer_id):
 
     app.logger.info("Customer with ID [%s] delete complete.", customer_id)
     return "", status.HTTP_204_NO_CONTENT
+
+
+######################################################################
+# SUSPEND A CUSTOMER
+######################################################################
+@app.route("/customers/<uuid:customer_id>/suspend", methods=["PUT"])
+def suspend_customer(customer_id):
+    """
+    Suspend a Customer
+
+    This endpoint will suspend a Customer based on the id specified in the path
+    """
+    app.logger.info("Request to suspend customer with id [%s]", customer_id)
+
+    customer = Customers.find(customer_id)
+    if not customer:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Customer with id '{customer_id}' was not found.",
+        )
+
+    customer.suspend()
+    app.logger.info("Customer with ID [%s] suspended.", customer_id)
+    return jsonify(customer.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# UNSUSPEND A CUSTOMER
+######################################################################
+@app.route("/customers/<uuid:customer_id>/unsuspend", methods=["PUT"])
+def unsuspend_customer(customer_id):
+    """
+    Unsuspend a Customer
+
+    This endpoint will unsuspend a Customer based on the id specified in the path
+    """
+    app.logger.info("Request to unsuspend customer with id [%s]", customer_id)
+
+    customer = Customers.find(customer_id)
+    if not customer:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Customer with id '{customer_id}' was not found.",
+        )
+
+    customer.unsuspend()
+    app.logger.info("Customer with ID [%s] unsuspended.", customer_id)
+    return jsonify(customer.serialize()), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -472,3 +472,94 @@ class TestCustomersService(TestCase):
         """It should return 404 for an invalid ID format in the URL"""
         response = self.client.delete(f"{BASE_URL}/this-is-not-a-uuid")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    ######################################################################
+    #  S U S P E N D / U N S U S P E N D   C U S T O M E R   T E S T S
+    ######################################################################
+
+    def test_suspend_active_customer(self):
+        """It should Suspend an active customer"""
+        # Create a customer with suspended=False (default)
+        test_customer = self._create_customers_in_db(1)[0]
+        self.assertFalse(test_customer.suspended)
+
+        # Suspend the customer
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/suspend")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.get_json()
+        self.assertTrue(data["suspended"])
+
+        response = self.client.get(f"{BASE_URL}/{test_customer.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertTrue(data["suspended"])
+
+    def test_suspend_already_suspended_customer(self):
+        """It should handle suspending an already suspended customer"""
+        # Create and suspend a customer
+        test_customer = self._create_customers_in_db(1)[0]
+        test_customer.suspend()
+        self.assertTrue(test_customer.suspended)
+
+        # Suspend again
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/suspend")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Checking customer remains suspended
+        data = response.get_json()
+        self.assertTrue(data["suspended"])
+
+    def test_unsuspend_suspended_customer(self):
+        """It should Unsuspend a suspended customer"""
+        # Create and suspend a customer
+        test_customer = self._create_customers_in_db(1)[0]
+        test_customer.suspend()
+        self.assertTrue(test_customer.suspended)
+
+        # Unsuspend the customer
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/unsuspend")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.get_json()
+        self.assertFalse(data["suspended"])
+
+        response = self.client.get(f"{BASE_URL}/{test_customer.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertFalse(data["suspended"])
+
+    def test_unsuspend_already_active_customer(self):
+        """It should handle unsuspending an already active customer"""
+        # Create a customer (default suspended=False)
+        test_customer = self._create_customers_in_db(1)[0]
+        self.assertFalse(test_customer.suspended)
+
+        # Unsuspend an already active customer
+        response = self.client.put(f"{BASE_URL}/{test_customer.id}/unsuspend")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.get_json()
+        self.assertFalse(data["suspended"])
+
+    def test_suspend_non_existent_customer(self):
+        """It should return 404 when suspending a non-existent customer"""
+
+        test_customer = CustomersFactory()
+        non_existent_id = test_customer.id
+
+        response = self.client.put(f"{BASE_URL}/{non_existent_id}/suspend")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("was not found", data["message"])
+
+    def test_unsuspend_non_existent_customer(self):
+        """It should return 404 when unsuspending a non-existent customer"""
+
+        test_customer = CustomersFactory()
+        non_existent_id = test_customer.id
+
+        response = self.client.put(f"{BASE_URL}/{non_existent_id}/unsuspend")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("was not found", data["message"])


### PR DESCRIPTION
This PR implements the customer suspension action, allowing service administrators to suspend and unsuspend customer accounts.

### **Changes TL;DR:**

`service/models.py`

- Added field: suspended (Boolean, default=False) to track customer suspension status
- Added instance method: suspend() - Sets customer account to suspended state
- Added instance method: unsuspend() - Reactivates a suspended customer account
- Updated method: serialize() - We also include suspended field in JSON output

`service/routes.py`

- Added endpoint: PUT /customers/<customer_id>/suspend - Suspends a customer account
- Added endpoint: PUT /customers/<customer_id>/unsuspend - Unsuspends a customer account

`tests/test_models.py` & `tests/test_routes.py`

- Basic suspend/unsuspend operations
- Idempotency tests for both operations
- Error handling for unpersisted objects
- 404 error handling for non-existent customers
- Updated 1 test to validate suspended field in serialization

<img width="648" height="263" alt="image" src="https://github.com/user-attachments/assets/a5f0be30-92e9-467e-9195-9ccd461f8156" />


