### PR TITLE
feat: implement health check endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -52,6 +52,16 @@ def index():
 
 
 ######################################################################
+# HEALTH CHECK
+######################################################################
+@app.route("/health", methods=["GET"])
+def health():
+    """Health check endpoint for Kubernetes liveness and readiness probes"""
+    app.logger.info("Request for health check")
+    return jsonify(status="OK"), status.HTTP_200_OK
+
+
+######################################################################
 # CREATE A CUSTOMER
 ######################################################################
 @app.route("/customers", methods=["POST"])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -105,6 +105,32 @@ class TestCustomersService(TestCase):
         )
 
     ######################################################################
+    #  H E A L T H   C H E C K   T E S T S
+    ######################################################################
+
+    def test_health_check(self):
+        """It should return health status with HTTP 200 OK"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify response is JSON
+        self.assertEqual(response.content_type, "application/json")
+
+        # Verify response body
+        data = response.get_json()
+        self.assertIsNotNone(data)
+        self.assertIn("status", data)
+        self.assertEqual(data["status"], "OK")
+
+    def test_health_check_response_format(self):
+        """It should return exactly the expected JSON format"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.get_json()
+        self.assertEqual(data, {"status": "OK"})
+
+    ######################################################################
     #  C R E A T E   C U S T O M E R   T E S T S
     ######################################################################
 


### PR DESCRIPTION
**Add GET /health endpoint for Kubernetes health checks**

This PR adds a new `/health` endpoint to the microservice to support Kubernetes liveness and readiness probes. The endpoint provides a simple health check that returns a JSON response indicating the service is operational.

**Changes Made**

service/routes.py

- Added new GET /health endpoint
- Returns JSON payload: {"status": "OK"}
- Returns HTTP 200 OK status code

tests/test_routes.py

- Added `test_health_check()` - Verifies endpoint returns 200 OK, correct content type, and valid JSON structure
- Added `test_health_check_response_format()` - Verifies exact response payload matches specification

<img width="1143" height="235" alt="image" src="https://github.com/user-attachments/assets/bf90121d-1ba6-4abc-9531-3612a919bd0c" />

