### PR TITLE
6.5: Add Build Image task using Buildah

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -16,7 +16,7 @@ spec:
       name: APP_NAME
       type: string
     - default: 'image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.APP_NAME):latest'
-      description: he name of the image to build
+      description: The name of the image to build
       name: IMAGE_NAME
       type: string
   tasks:
@@ -98,7 +98,47 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
-    # - name: buildah
+    - name: buildah
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: BUILD_ARGS
+          value:
+            - ''
+        - name: CONTEXT
+          value: .
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: FORMAT
+          value: oci
+        - name: BUILD_EXTRA_ARGS
+          value: ''
+        - name: PUSH_EXTRA_ARGS
+          value: ''
+        - name: SKIP_PUSH
+          value: 'false'
+        - name: TLS_VERIFY
+          value: 'true'
+        - name: VERBOSE
+          value: 'false'
+      runAfter:
+        - pylint
+        - pytest
+      taskRef:
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: buildah
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
     # - name: deploy-image
+    # - name: behave
   workspaces:
     - name: pipeline-workspace


### PR DESCRIPTION
Implemented Story #74.

- Added Buildah-based image build task to the Tekton pipeline.
- Updated `.tekton/pipeline.yaml` according to Sprint requirements.
- Ensures container images can be built in the CI/CD pipeline.

Please review when available. Thanks!
